### PR TITLE
Address ambiguity around patent grant

### DIFF
--- a/LICENSE.mustache
+++ b/LICENSE.mustache
@@ -8,8 +8,8 @@ This license lets you use and share this software for free, as
 long as you credit me when you build with it. Specifically:
 
 If you follow the rules below, you may do everything with
-this software that would otherwise infringe my copyright in
-it or any patent claim I can license that you would infringe
+this software that would otherwise infringe (i) my copyright in
+it or (ii) any patent claim I can license that you would infringe
 by using this software as of my latest contribution.
 
 1. If you run or combine this software with other software in


### PR DESCRIPTION
I'm wrestling with the patent grant here; the "or" is ambiguous. Two possible constructions:
- "you may do everything with ... any patent claim that I license": not consistent with other licenses as it doesn't tie the usage to this particular piece of software. (Though perhaps this is intentional, as the utility of this tie has always been somewhat debatable in the context of permissive licenses.)
- "you may do everything with this software that would otherwise infringe ... any patent claim I can license that you would infringe by using this software" - I think this is probably what you meant, but the repeated use of "infringe" makes me somewhat uncertain?

The pull request fixes the ambiguity with brute force. It does not fix the awkward dual "infringe"; I'd like something more parallel but I don't see an obvious change that would fix without running into complexity around the subtly but importantly different definitions of what is being licensed.